### PR TITLE
Adapt to deprecated `--dev`/`-D` poetry option.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.8"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 cookiecutter = "^2.1.1"
 
 [build-system]

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -11,7 +11,7 @@ click = "*"
 loguru = "*"
 PyYAML = "*"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "*"
 pytest-cov = "*"
 black = "*"


### PR DESCRIPTION
When adding dev dependencies using the `--dev` or `-D` option, poetry version 1.2.2 prints a deprecation review. This PR adapts to the suggested new way of adding dev dependencies.