### PR TITLE
fix: extraneous addopts

### DIFF
--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -26,7 +26,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-addopts = "--cov-report html:tests/coverage --cov={{ cookiecutter.project_slug }} --capture=sys --html=tests/report.html --self-contained-html"
+addopts = "--cov-report html:tests/coverage --cov={{ cookiecutter.project_slug }} --capture=sys"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Remove extra and unknown pytest options in `pyproject.toml`.

Closes #22.