### PR TITLE
feat: add `--version` option and document best practice

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/main.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/main.py
@@ -1,7 +1,22 @@
+"""Welcome to {{ cookiecutter.project_slug }}.
+
+Here we showcase our best practices for command line tool development.
+
+## Version Option
+
+Nearly all CL programs implement the `--version` option to display the currently
+used version of the program. `click` implements this with a very concise decorator
+that is applied to the top-level entry point, e.g. the below example `cli()` the
+`@click.version_option(__version__)` sets the displayed version.
+"""
 import click
 from loguru import logger as log
 
+from . import __version__
+
+
 @click.command()
+@click.version_option(__version__)
 @click.argument("name", type=str)
 def cli(name: str) -> None:
     """ This internal function is called by the click-decorated function.


### PR DESCRIPTION
Implements a version option.

Depends on #20. Closes #21.